### PR TITLE
UI: Misc command tweaks

### DIFF
--- a/src/JED_MAIN.DFM
+++ b/src/JED_MAIN.DFM
@@ -563,7 +563,6 @@ object JedMain: TJedMain
       end
       object SaveJKLGob1: TMenuItem
         Caption = 'Save JKL And GOB'
-        ShortCut = 113
         OnClick = SaveJKLGob1Click
       end
       object SaveJKLGOBandTest1: TMenuItem
@@ -701,7 +700,7 @@ object JedMain: TJedMain
       end
       object Viewtogrid1: TMenuItem
         Caption = '&View to grid'
-        ShortCut = 106
+        ShortCut = 113
         OnClick = Viewtogrid1Click
       end
       object GridtoView1: TMenuItem

--- a/src/JED_MAIN.DFM
+++ b/src/JED_MAIN.DFM
@@ -688,11 +688,11 @@ object JedMain: TJedMain
         OnClick = JumptoObject1Click
       end
       object MUSnapGridTo: TMenuItem
-        Caption = '&Snap  Grid to Object'
+        Caption = '&Snap Grid to Object'
         OnClick = MUSnapGridToClick
       end
       object SnapViewToObject: TMenuItem
-        Caption = 'Snap View &To Object'
+        Caption = '&Snap View to Object'
         OnClick = SnapViewToObjectClick
       end
       object SetMapGeoBackfaceCulling: TMenuItem
@@ -701,6 +701,7 @@ object JedMain: TJedMain
       end
       object Viewtogrid1: TMenuItem
         Caption = '&View to grid'
+        ShortCut = 106
         OnClick = Viewtogrid1Click
       end
       object GridtoView1: TMenuItem

--- a/src/JED_MAIN.PAS
+++ b/src/JED_MAIN.PAS
@@ -1729,7 +1729,6 @@ begin
     AddKBItem(miMap, 'Zoom at cursor'#9'Mouse Wheel', #0, []);
     AddKBItem(miMap, 'Zoom in', Char(VK_ADD), []);
     AddKBItem(miMap, 'Zoom out', Char(VK_SUBTRACT), []);
-    AddKBItem(miMap, 'View To Grid', Char(VK_MULTIPLY), []);
 
     AddKBItem(miGrid, 'Top view&&grid', '1', [ssShift]);
     AddKBItem(miGrid, 'Front view&&grid', '2', [ssShift]);
@@ -2618,8 +2617,6 @@ begin
                 MM_LT:
                     BringLightToSurf(Cur_LT, Cur_SC, Cur_SF);
             end;
-        VK_MULTIPLY:
-            SetViewToGrid;
         Ord('E'):
             SetMapMode(MM_ED);
         Ord('X'):

--- a/src/U_PREVIEW.PAS
+++ b/src/U_PREVIEW.PAS
@@ -382,46 +382,22 @@ begin
         if Shift = [ssShift] then
           JedMain.ShiftTexture(st_left)
         else if Shift = [ssCtrl] then
-          JedMain.RotateTexture(st_left)
-        else if ssAlt in Shift then
-          begin
-            self.MoveCameraLeft;
-          end
-        else
-          GetCamera().RotateYaw(-10);
+          JedMain.RotateTexture(st_left);
       VK_RIGHT:
         if Shift = [ssShift] then
           JedMain.ShiftTexture(st_right)
         else if Shift = [ssCtrl] then
-          JedMain.RotateTexture(st_right)
-        else if ssAlt in Shift then
-          begin
-            self.MoveCameraRight;
-          end
-        else
-          GetCamera().RotateYaw(10);
+          JedMain.RotateTexture(st_right);
       VK_UP:
         if Shift = [ssShift] then
           JedMain.ShiftTexture(st_up)
         else if Shift = [ssCtrl] then
-          JedMain.RaiseObject(ro_up)
-        else
-        begin
-          self.MoveCameraForward;
-        end;
+          JedMain.RaiseObject(ro_up);
       VK_DOWN:
         if Shift = [ssShift] then
           JedMain.ShiftTexture(st_down)
         else if Shift = [ssCtrl] then
-          JedMain.RaiseObject(ro_down)
-        else
-          self.MoveCameraBackward;
-      VK_NEXT:
-          GetCamera().RotatePitch(10);
-      VK_PRIOR:
-        begin
-          GetCamera().RotatePitch(-10);
-        end;
+          JedMain.RaiseObject(ro_down);
       VK_HOME:
         if Shift = [] then
           GetCamera().rotation.pitch := 0
@@ -435,8 +411,8 @@ begin
           self.MoveThingLeft
         else if (Shift = [ssAlt]) then // Un-adjoin
           JedMain.FormKeyDown(nil, Key, Shift)
-        else
-          self.MoveCameraUp;
+        else // Adjoin
+          JedMain.FormKeyDown(nil, Key, Shift);
       Ord('B'):
         if Shift = [] then  // Bring Thing to surface
           JedMain.FormKeyDown(nil, Key, Shift);
@@ -1110,18 +1086,8 @@ begin
   MenuNoClipSelectionOutline.Checked := P3DNoClipSelectionOutline;
 
   AddKBItem(miControl, 'View mode'#9'Right Mouse Button + W/A/S/D', #0, []);
-  AddKBItem(miControl, 'Rotate right', Char(VK_RIGHT), []);
-  AddKBItem(miControl, 'Rotate right', Char(VK_RIGHT), []);
-  AddKBItem(miControl, 'Rotate left', Char(VK_LEFT), []);
-  AddKBItem(miControl, 'Move forth', Char(VK_UP), []);
-  AddKBItem(miControl, 'Move back', Char(VK_DOWN), []);
-  AddKBItem(miControl, 'Sidestep left', Char(VK_LEFT), [ssAlt]);
-  AddKBItem(miControl, 'Sidestep right', Char(VK_RIGHT), [ssAlt]);
-
-  AddKBItem(miControl, 'Look up', Char(VK_NEXT), []);
-  AddKBItem(miControl, 'Look down', Char(VK_PRIOR), []);
-  AddKBItem(miControl, 'Move up', 'A', []);
-  AddKBItem(miControl, 'Move down', 'Z', []);
+  AddKBItem(miControl, 'Move up'#9'Right Mouse Button + Q', #0, []);
+  AddKBItem(miControl, 'Move down'#9'Right Mouse Button + E', #0, []);
 
   AddKBItem(miControl, 'Select surface/thing'#9'Click', #0, []);
   AddKBItem(miControl, 'Clear multiselection', Char(VK_BACK), []);
@@ -1165,7 +1131,7 @@ begin
   AddKBItem(miEdit, 'Fix solid surface(s)', 'R', [ssCtrl], JedMain.OnFixSolidSurfaces);
 
   AddKBItem(miEdit, 'Unadjoin', 'A', [ssAlt]);
-  AddKBItem(miEdit, 'Adjoin', 'A', [ssCtrl]);
+  AddKBItem(miEdit, 'Adjoin', 'A', []);
   AddKBItem(miEdit, 'Join sectors/surfaces', 'J', []);
   AddKBItem(miEdit, 'Merge', 'M', []);
 


### PR DESCRIPTION
Functional changes:
- Changed Adjoin action in 3D Preview mode from Ctrl+A to A to make behaviour consistent with Wireframe mode
- Moved Move Up/Down actions from A/Z to Q/E to make space for change above and to make behaviour consistent with controls in View mode in 3D Preview

Label fixes:
- Removed extra space in Snap Grid to Object label
- Consistent capitalization of "to" in Snap View to Object label
- Added information about existing hotkey to View to Grid label under Commands
- Removed duplicate Rotate right label in 3D Preview under Commands->Control
- Fixed hotkey information for Look Up/Down labels (they were reversed)